### PR TITLE
Remove trailing comma from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "export": "hasura metadata export",
+    "export": "hasura metadata export"
   },
   "devDependencies": {
     "hasura-cli": "^2.0.1"


### PR DESCRIPTION
My version of npm doesn't like the trailing comma:

```
npm ERR! code EJSONPARSE
npm ERR! file /nas/achin/devel/cb_api/package.json
npm ERR! JSON.parse Failed to parse json
npm ERR! JSON.parse Unexpected token } in JSON at position 59 while parsing near '...metadata export",
```